### PR TITLE
fix: change subdir to lower camel case

### DIFF
--- a/content/en/docs/reference/kluctl-project/_index.md
+++ b/content/en/docs/reference/kluctl-project/_index.md
@@ -28,14 +28,14 @@ deployment:
 clusters:
   project:
     url: https://github.com/kluctl/kluctl-example-clusters
-    subdir: clusters
+    subDir: clusters
 
 # This is optional. If omitted, `<baseDirOfKluctlYml>/.sealed-secrets` will be used
 # See "External Projects" for details
 sealedSecrets:
   project:
     url: https://github.com/kluctl/kluctl-example
-    subdir: .sealed-secrets
+    subDir: .sealed-secrets
 
 targets:
   # test cluster, dev env

--- a/content/en/docs/reference/kluctl-project/external-projects.md
+++ b/content/en/docs/reference/kluctl-project/external-projects.md
@@ -29,7 +29,7 @@ deployment:
   project:
     url: <git-url>
     ref: <tag-or-branch>
-    subdir: <subdir>
+    subDir: <subdir>
 ```
 
 ### project.url


### PR DESCRIPTION
Change `subdir` to lower camel case to match implementation