### PR TITLE
Add issue template for adopter

### DIFF
--- a/.github/ISSUE_TEMPLATE/ADOPTER.yml
+++ b/.github/ISSUE_TEMPLATE/ADOPTER.yml
@@ -1,0 +1,29 @@
+name: Adopter
+description: Create a request for adding your company to the adopters page
+body:
+  - type: input
+    id: company
+    attributes:
+      label: What is the name of your company?
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What does your company do and how do you use kluctl?
+    validations:
+      required: true
+  - type: input
+    id: logo
+    attributes:
+      label: URL to your company logo
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: authorization
+      description: By submitting this request, you agree that you are authorized to add the company to this page and that we can use your logo.
+      options:
+        - label: I agree to the statement above.
+          required: true


### PR DESCRIPTION
# Description

This PR adds an issue template for adopters, than can be used to send a request for adding a company to the adopters page.