### PR TITLE
sync docs:remove verbose git output

### DIFF
--- a/sync-docs/main.go
+++ b/sync-docs/main.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	yaml3 "gopkg.in/yaml.v3"
 	"io"
 	"io/fs"
 	"net/http"
@@ -18,6 +16,9 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/Masterminds/semver/v3"
+	yaml3 "gopkg.in/yaml.v3"
 
 	cp "github.com/otiai10/copy"
 )
@@ -119,7 +120,7 @@ func doMain() error {
 			return err
 		}
 
-		cmd = exec.Command("git", "checkout", version, "--")
+		cmd = exec.Command("git", "checkout", "-b", fmt.Sprintf("%s-temp-branch", version), version)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.Dir = repoDir


### PR DESCRIPTION
…rom the tags

# Description

Since the script checkout to a tag of the assets repo, there was a repeated log of the warning as tag commit a non-tip of a branch commit. That unwanted warning can be simply ignored by checkout a new temp branch.

```
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Content change (Adding content, Changing content, Fix typo)
- [ ] Style change (Change of CSS)
- [ ] Change of functionality (Add/Change functionality, e.g. new libraries)

All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
