### PR TITLE
feat(adopters): rename E3DC company name

### DIFF
--- a/data/adopters.yaml
+++ b/data/adopters.yaml
@@ -11,7 +11,7 @@ list:
     testimonial: "We use Kluctl as a core deployment tool with components that we love being the Helm Integration, Secrets Transformer, Deployment Diffs, flexible Deployment Targets and the Templating with Jinja Vars Substitution."
     author: 'Mark Cupitt, Head of Global Operations and Engineering'
   - logo: "images/adopters/e3dc.svg"
-    description: "E3DC, a Hagerenergy GmbH company, the all-in-one energy storage solution"
+    description: "Hagerenergy GmbH - all-in-one energy solutions"
     url: https://e3dc.com
     testimonial: "Easy and straight forward kubernetes deployments which makes our live in the GitOps and DevOps daily business much more easy and reliable."
     author: 'Timo Roewekamp, IT Systems Engineer'


### PR DESCRIPTION
# Description

The company name of E3DC adopter was to long, so it ended up in two lines.
This commit is only for fixing this.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Content change (Adding content, Changing content, Fix typo)

All Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code